### PR TITLE
Feature symlinkfix

### DIFF
--- a/install/install-oe.sh
+++ b/install/install-oe.sh
@@ -132,9 +132,9 @@ Do you wish to continue?
 fi
 
 if [ "$develop" = 1 ]; then
-	oe-checkout $branch -f --no-migrate --no-summary --develop
+	oe-checkout $branch -f --no-migrate --no-summary --no-fix --develop
 else
-	oe-checkout $branch -f --no-migrate --no-summary
+	oe-checkout $branch -f --no-migrate --no-summary --no-fix 
 fi
 
 cd /var/www/openeyes/protected
@@ -168,6 +168,8 @@ if [ ! `grep -c '^vagrant:' /etc/passwd` = '1' ]; then
 	chown -R www-data:www-data /var/www/*
 fi
 
+# call oe-fix
+oe-fix
 							
 if [ ! "$live" = "1" ]; then
 	echo Creating blank database

--- a/install/oe-checkout
+++ b/install/oe-checkout
@@ -22,6 +22,7 @@ defaultbranch=master
 force=0
 killmodules=0
 migrate=1
+fix=1
 customgitroot=0
 nosummary=0
 branch=$defaultbranch
@@ -45,6 +46,9 @@ case $i in
 		;;
 	--no-summary) nosummary=1
 		## don't show summary of checkout at completion
+		;;
+	--no-fix) fix=0
+		## don't run oe-fix at completion
 		;;
 	*)  if [ ! -z "$i" ]; then 
 			if [ "$customgitroot" = "1" ]; then
@@ -207,8 +211,7 @@ done
 
 
 # Now reset/relink various config files etc
-oe-fix
-
+if [ "$fix" = "1" ]; then  oe-fix; fi
 
 cd "$dir"
 

--- a/install/oe-fix
+++ b/install/oe-fix
@@ -29,31 +29,20 @@ if [ ! -d "protected/config/local" ]; then
 fi;
 
 # Make sure yii framework found/linked
-linkme=0
-if [ ! -d "/var/www/openeyes/vendor/yiisoft/yii" ]; then 
-	# if directory doesn't exist
-	linkme=1;
+rm "/var/www/openeyes/vendor/yiisoft/yii" 2>/dev/null || :
+mkdir -p /var/www/openeyes/vendor/yiisoft
+if [ ! "$envtype" = "VAGRANT" ]; then chown -R www-data:www-data /var/www/openeyes/vendor; fi
+
+if [ -d "/usr/lib/openeyes/yii" ]; then
+	# v1.12+
+	echo "Linking Yii framework to /usr/lib/openeyes/yii" 
+	ln -s /usr/lib/openeyes/yii /var/www/openeyes/vendor/yiisoft/yii 
 else
-	if [ -h "/var/www/openeyes/vendor/yiisoft/yii" ]; then
-		# if director exists, but is a symlink
-		linkme=1
-	fi
+	#fix for pre v1.12
+	echo "Linking Yii framework to /var/www/openeyes/protected/yii"
+	ln -s /var/www/openeyes/protected/yii /var/www/openeyes/vendor/yiisoft/yii 
 fi
-if [ $linkme = 1 ]; then
-		rm "/var/www/openeyes/vendor/yiisoft/yii" 2>/dev/null || :
-		mkdir -p /var/www/openeyes/vendor/yiisoft
-		if [ ! "$envtype" = "VAGRANT" ]; then chown -R www-data:www-data /var/www/openeyes/vendor; fi
-		
-		if [ -d "/usr/lib/openeyes/yii" ]; then
-			# v1.12+
-			echo "Linking Yii framework to /usr/lib/openeyes/yii" 
-			ln -s /usr/lib/openeyes/yii /var/www/openeyes/vendor/yiisoft/yii 
-		else
-			#fix for pre v1.12
-			echo "Linking Yii framework to /var/www/openeyes/protected/yii"
-			ln -s /var/www/openeyes/protected/yii /var/www/openeyes/vendor/yiisoft/yii 
-		fi
-fi
+
 
 # Make sure vendor directory found/linked
 if [ ! -d "/var/www/openeyes/protected/vendors" ]; then

--- a/install/oe-fix
+++ b/install/oe-fix
@@ -29,20 +29,38 @@ if [ ! -d "protected/config/local" ]; then
 fi;
 
 # Make sure yii framework found/linked
-if [ ! -d "/var/www/openeyes/vendor/yiisoft/yii" ]; then
-  if [ ! -h "/var/www/openeyes/vendor/yiisoft/yii" ]; then
-    echo Linking Yii framework
-    mkdir -p /var/www/openeyes/vendor/yiisoft
-    if [ ! "$envtype" = "VAGRANT" ]; then chown -R www-data:www-data /var/www/openeyes/vendor; fi
-    ln -s /usr/lib/openeyes/yii /var/www/openeyes/vendor/yiisoft/yii
-  fi
+linkme=0
+if [ ! -d "/var/www/openeyes/vendor/yiisoft/yii" ]; then 
+	# if directory doesn't exist
+	linkme=1;
+else
+	if [ -h "/var/www/openeyes/vendor/yiisoft/yii" ]; then
+		# if director exists, but is a symlink
+		linkme=1
+	fi
+fi
+if [ $linkme = 1 ]; then
+		rm "/var/www/openeyes/vendor/yiisoft/yii" 2>/dev/null || :
+		mkdir -p /var/www/openeyes/vendor/yiisoft
+		if [ ! "$envtype" = "VAGRANT" ]; then chown -R www-data:www-data /var/www/openeyes/vendor; fi
+		
+		if [ -d "/usr/lib/openeyes/yii" ]; then
+			# v1.12+
+			echo "Linking Yii framework to /usr/lib/openeyes/yii" 
+			ln -s /usr/lib/openeyes/yii /var/www/openeyes/vendor/yiisoft/yii 
+		else
+			#fix for pre v1.12
+			echo "Linking Yii framework to /var/www/openeyes/protected/yii"
+			ln -s /var/www/openeyes/protected/yii /var/www/openeyes/vendor/yiisoft/yii 
+		fi
 fi
 
 # Make sure vendor directory found/linked
 if [ ! -d "/var/www/openeyes/protected/vendors" ]; then
 	echo Linking vendor framework
-	ln -s /usr/lib/openeyes/vendors /var/www/openeyes/protected/vendors
-	chown -R www-data:www-data /var/www/openeyes/protected/vendors
+	ln -s /usr/lib/openeyes/vendors /var/www/openeyes/protected/vendors 
+	chown -R www-data:www-data /var/www/openeyes/protected/vendors 2>/dev/null || :
+	if [ ! $? = 0 ]; then echo "unable to link vendors - this is expected for versions prior to v1.12"; fi
 fi
 
 # Clear caches


### PR DESCRIPTION
Fixes symlinks for pre v1.12 versions.
NOTE: to use symlinks on Windows hosts, vagrant must be run as as administrator (elevated command prompt)
