### PR TITLE
Fix for install of Chrome and adding in VMWare Fusion support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,16 +26,16 @@ managed/setup by Vagrant. Vagrant is not essential (see live use setup below) bu
 
 #### Installing for Mac OS X 10.6 or later
 
-<b>NOTE:</b> These instructions assume you are installing in to a directory called ~/openeyes on the host. You may change this path as you see fit.
+**NOTE:** These instructions assume you are installing in to a directory called ~/openeyes on the host. You may change this path as you see fit.
 
 Software required:
 
-1. Vagrant: https://www.vagrantup.com/downloads.html
-2. VirtualBox: https://www.virtualbox.org/wiki/Downloads
-3. Git: https://git-scm.com/downloads
+1. Vagrant: [https://www.vagrantup.com/downloads.html](https://www.vagrantup.com/downloads.html)
+2. VirtualBox: [https://www.virtualbox.org/wiki/Downloads](https://www.virtualbox.org/wiki/Downloads)
+3. Git: [https://git-scm.com/downloads](https://git-scm.com/downloads)
 
 
-<pre>
+```
 1. Install Vagrant, VirtualBox and Git as listed above.
 2. From a terminal window, change to your home directory. Run: cd ~
 3. Clone OpenEyes/oe_installer to a directory of your choice. Run: git clone https://github.com/openeyes/oe_installer.git ~/openeyes
@@ -45,25 +45,25 @@ Software required:
 7. Run the following commands (on the terminal of the vagrant box):
   i. sudo /vagrant/install/install-system.sh
   ii. sudo /vagrant/install/install-oe.sh
-</pre>
+```
 
 At this point you should have a fully working OpenEyes server, reachable at http://localhost:8888 or http://192.168.90.100
 You can follow the sections below on [Default development tools](#default-development-tools) and [Additional development tools](#additional-development-tools) should you need them.
 
 #### Installing for Windows 7 or later
-<b>IMPORTANT:</b> For this installer to run, the vagrant up command must be issued from a command window with elevated priviledges (admin command prompt). This is due to a limitation with VirtualBox not being able to create symbolic links to shared folders unless it has admin rights. Failure to do this will result in unpredictable consequences!
+**IMPORTANT:** For this installer to run, the vagrant up command must be issued from a command window with elevated priviledges (admin command prompt). This is due to a limitation with VirtualBox not being able to create symbolic links to shared folders unless it has admin rights. Failure to do this will result in unpredictable consequences!
 
-<b>NOTE:</b> These instructions assume you are installing in to a directory called C:\openeyes on the host. You may change this 
+**NOTE:** These instructions assume you are installing in to a directory called C:\openeyes on the host. You may change this 
 path as you see fit. However, please note that Windows struggles with filenames longer than 275 characters on file shares, so
 keep this path below 30 characters. You can map a longer pathname to a drive letter using the subst command.
 
 Software required:
 
-1. Vagrant: https://www.vagrantup.com/downloads.html
-2. VirtualBox: https://www.virtualbox.org/wiki/Downloads
-3. Git: https://git-scm.com/downloads
+1. Vagrant: [https://www.vagrantup.com/downloads.html](https://www.vagrantup.com/downloads.html)
+2. VirtualBox: [https://www.virtualbox.org/wiki/Downloads](https://www.virtualbox.org/wiki/Downloads)
+3. Git: [https://git-scm.com/downloads](https://git-scm.com/downloads)
 
-<pre>
+```
 1. Install Vagrant, VirtualBox and Git as listed above.
 2. From an administrative terminal window, change to your root directory. Run: cd c:\
 3. Clone OpenEyes/oe_installer to a directory of your choice. Run: git clone https://github.com/openeyes/oe_installer.git c:\openeyes
@@ -73,7 +73,7 @@ Software required:
 7. From within the vagrant box, run the following commands:
   i. sudo /vagrant/install/install-system.sh
   ii. sudo /vagrant/install/install-oe.sh
-</pre>
+```
 
 At this point you should have a fully working OpenEyes server, reachable at localhost:8888 or 192.168.90.100.
 You can follow the sections below on [Default development tools](#default-development-tools) and [Additional development tools](#additional-development-tools) should you need them.
@@ -83,10 +83,11 @@ You can follow the sections below on [Default development tools](#default-develo
 File shares under VirtualBox are pretty slow in version 5. You can try swapping to Version 4.3.x (any version between these two does not seem to work).
 If you find the command prompt very slow on the virtual machine, you can remove the coloured command prompt (which displays the current branch if you
 are in a git repository directory). To remove this, edit the /etc/bash.bashrc file and add the second PS1 line (shown below) at the end:
-<pre>
+
+```
 PS1="\e[0m\n\e[44m\e[97m \u@\h \e[41m\$(gitbranch)\e[0m\n\w>"
 PS1="u@\h\n\w>"
-</pre>
+```
 
 Note that changes only take effect on subsequent logins.
 
@@ -106,22 +107,25 @@ For example, to get the latest build and all database changes, you will need to 
 ### Additional development tools
 
 If you require behat (running the selenium UI tests), then from the VM run the following command:
-<pre>
+
+```
   sudo /vagrant/install/install-behat.sh
-</pre>
+```
 
 If you require PHP unit tests, or modify any SASS or CSS or Javascript, then you will need the additional dev tools. From the 
 VM run the following command:
-<pre>
+
+```
   sudo /vagrant/install/install-devtools.sh
-</pre>
+```
 
 
 If you wish to run these extra tools via Jenkins, you can also install the pre-configured Jenkins suite. From the 
 VM run the following command:
-<pre>
+
+```
   sudo /vagrant/install/install-jenkins.sh
-</pre>
+```
 
 
 ## Installing for live use
@@ -129,7 +133,7 @@ VM run the following command:
 This section assumes you are installing OpenEyes on a virtual machine, (other than one built by Vagrant), a cloud server (such as AWS) or a 
 physical server, and it is intended for non-development, and that your home directory is /home/me (you can modify accordingly).
 
-<pre>
+```
 Install Ubuntu 14.04 LTS. Minimal installation, no software packages (except ssh server)
 You are expected to know the root password and the username/password of a normal user.
 Log on as your normal user (presumed to be 'me' for this guide - amend as required)
@@ -140,20 +144,20 @@ Symlink /home/me/openeyes to /vagrant. Run: sudo ln -s /home/me/openeyes /vagran
 Run: sudo /vagrant/install/install-system.sh
 Run: sudo /vagrant/install/install-oe.sh
 Run: sudo oe-migrate
-</pre>
+```
 
-At this point you have a working server running on localhost (or your assigned IP address). You may wish to edit /etc/apache2/sites-available/000-default.conf 
+At this point you have a working server running on localhost (or your assigned IP address). You may wish to edit `/etc/apache2/sites-available/000-default.conf`
 and set the ServerName directive to your chosen domain name (apache configuration knowledge required).
  
-There is nothing to stop you from using this server configuration for development, and following the Default and Additional development 
-tools sections above. However such use is outside our prescribed method for development.
+There is nothing to stop you from using this server configuration for development, and following the Default and Additional development tools sections above. However such use is outside our prescribed method for development.
 
 
 ## Upgrading a live server to v1.12
 
 V1.12 represents a significant change in some code layout from previous versions. As a result, the safest upgrade path is to completely replace
 all code with a newly checked out site. Each live deployment will have their own minor differences, so only outline directions are provided here.
-<pre>
+
+```
 + Back-up the database 
 + Back up the /var/www/openeyes directories
 + Clone the oe_installer repository to a directory
@@ -161,4 +165,4 @@ all code with a newly checked out site. Each live deployment will have their own
 + Run: sudo upgrade-oe.sh 
 + Edit the file /etc/openeyes/db.conf with your database credentials
 + Edit the /var/www/openeyes/protected/config/local/common.php file with values from your backed up copy
-</pre>
+```

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,16 +1,50 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+Vagrant.require_version ">= 1.5"
+
+PLUGINS = %w(vagrant-auto_network vagrant-hostsupdater)
+
+PLUGINS.reject! { |plugin| Vagrant.has_plugin? plugin }
+
+unless PLUGINS.empty?
+  print "The following plugins will be installed: #{PLUGINS.join ", "} continue? [Y/n]: "
+  unless ['no', 'n'].include? $stdin.gets.strip.downcase
+    PLUGINS.each do |plugin|
+      system("vagrant plugin install #{plugin}")
+      puts
+    end
+  end
+  puts "Please run again"
+  exit 1
+end
+
+
 Vagrant.configure(2) do |config|
   config.vm.box = "ubuntu/trusty64"
   config.vm.box_check_update = true
 
+  config.vm.hostname = "openeyes.vm"
+
   config.vm.network :forwarded_port, host: 8888, guest: 80
   config.vm.network :forwarded_port, host: 3333, guest: 3306
-  config.vm.network "private_network", ip: "192.168.90.100"
+  config.vm.network "private_network", :auto_network => true
   config.vm.synced_folder "./www/", "/var/www/", id: "vagrant-root", type: 'nfs', create: true
+
+  VirtualBox
   config.vm.provider "virtualbox" do |vb|
     vb.memory = "768"
     vb.gui = true
   end
+
+  # VMWare Fusion
+  # config.vm.provider "vmware_fusion" do |vf, override|
+  #   override.vm.box = "puppetlabs/ubuntu-14.04-64-nocm"
+  #   vf.vmx["displayname"] = "Openeyes"
+  #   vf.vmx["memsize"] = "1024"
+  #   vf.vmx["numvcpus"] = "1"
+  # end
+
+  config.hostsupdater.remove_on_suspend = true
+
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -31,19 +31,19 @@ Vagrant.configure(2) do |config|
   config.vm.network "private_network", :auto_network => true
   config.vm.synced_folder "./www/", "/var/www/", id: "vagrant-root", type: 'nfs', create: true
 
-  VirtualBox
-  config.vm.provider "virtualbox" do |vb|
-    vb.memory = "768"
-    vb.gui = true
+  # VirtualBox
+  config.vm.provider "virtualbox" do |v|
+    v.memory = "768"
+    v.gui = true
   end
 
   # VMWare Fusion
-  # config.vm.provider "vmware_fusion" do |vf, override|
-  #   override.vm.box = "puppetlabs/ubuntu-14.04-64-nocm"
-  #   vf.vmx["displayname"] = "Openeyes"
-  #   vf.vmx["memsize"] = "1024"
-  #   vf.vmx["numvcpus"] = "1"
-  # end
+  config.vm.provider "vmware_fusion" do |v, override|
+    override.vm.box = "puppetlabs/ubuntu-14.04-64-nocm"
+    v.vmx["displayname"] = "Openeyes"
+    v.vmx["memsize"] = "1024"
+    v.vmx["numvcpus"] = "1"
+  end
 
   config.hostsupdater.remove_on_suspend = true
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,6 +19,7 @@ unless PLUGINS.empty?
   exit 1
 end
 
+AutoNetwork.default_pool = "172.16.0.0/24"
 
 Vagrant.configure(2) do |config|
   config.vm.box = "ubuntu/trusty64"
@@ -30,6 +31,10 @@ Vagrant.configure(2) do |config|
   config.vm.network :forwarded_port, host: 3333, guest: 3306
   config.vm.network "private_network", :auto_network => true
   config.vm.synced_folder "./www/", "/var/www/", id: "vagrant-root", type: 'nfs', create: true
+
+  # Prefer VMware Fusion before VirtualBox
+  config.vm.provider "vmware_fusion"
+  config.vm.provider "virtualbox"
 
   # VirtualBox
   config.vm.provider "virtualbox" do |v|

--- a/install/install-behat.sh
+++ b/install/install-behat.sh
@@ -25,7 +25,7 @@ fi
 # Get behat
 cd /vagrant/install
 rm -rf /var/www/behat
-git clone http://github.com/Behat/Behat.git /var/www/behat 
+git clone http://github.com/Behat/Behat.git /var/www/behat
 cd /var/www/behat
 
 cp /vagrant/install/composer.json /var/www/behat/
@@ -62,7 +62,7 @@ cp /vagrant/install/behat /var/www/behat/bin/
 apt-get install -y --force-yes xorg jwm firefox
 
 wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
-echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list
+echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list
 apt-get update
 apt-get install -y google-chrome-stable
 
@@ -88,7 +88,7 @@ echo "exec /usr/bin/jwm" > /home/$user/.xsession
 
 # Clean out some irrelevant files
 rm LICENSE *.md
-chmod +x start-selenium-server.sh 
+chmod +x start-selenium-server.sh
 
 
 # Reset file permissions and ownership in behat directory


### PR DESCRIPTION
- Fix for `install-behat.sh` to install Chrome correctly - updated the apt source list so that Chrome is now installed. (closes #8 )
- Tidied the `README.md` file to use markdown rather than a combination of HTML / Md
- Added in support for VMWare Fusion to the vagrant file
- Added in auto networking on Vagrant site is now available via [http://openeyes.vm](http://openeyes.vm)
