### PR TITLE
OE-7283: Added ffmpeg to the list of dependencies + Event Image Cron Job

### DIFF
--- a/install/eventimage
+++ b/install/eventimage
@@ -1,0 +1,3 @@
+# /etc/cron.d/hotlist: hotlist item closer
+# Run a job every minute (unless the job is already running) to update out of date event preview images
+*/1 * * * *	root	/usr/bin/flock -n /tmp/eventimage.lockfile php /var/www/openeyes/protected/yiic eventimage create >/dev/null 2>&1

--- a/install/install-oe.sh
+++ b/install/install-oe.sh
@@ -364,6 +364,8 @@ fi
 # copy cron tasks
 sudo cp -f /vagrant/install/hotlist /etc/cron.d/
 sudo chmod 0644 /etc/cron.d/hotlist
+sudo cp -f /vagrant/install/eventimage /etc/cron.d/
+sudo chmod 0644 /etc/cron.d/eventimage
 
 echo ""
 oe-which

--- a/install/install-system.sh
+++ b/install/install-system.sh
@@ -83,6 +83,8 @@ sudo add-apt-repository ppa:openjdk-r/ppa -y
 
 
 echo Performing package updates
+# ffmpeg isn't supported on trusty, so a third party ppa is required
+add-apt-repository ppa:mc3man/gstffmpeg-keep
 sudo apt-get -y update
 sudo apt-get -y upgrade
 sudo apt-get -y autoremove
@@ -93,7 +95,7 @@ echo Installing required system packages
 # debconf-set-selections <<< 'mariadb-server-5.5 mysql-server/root_password password password'
 # debconf-set-selections <<< 'mariadb-server-5.5 mysql-server/root_password_again password password'
 
-sudo apt-get install -y git-core software-properties-common php5.6 php5.6-mbstring imagemagick libjpeg62 mariadb-server mariadb-client debconf-utils unzip xfonts-75dpi default-jre libgamin0 gamin openjdk-7-jdk openjdk-8-jdk xfonts-base ruby ant libbatik-java libreoffice-core libreoffice-common libreoffice-writer libapache2-mod-php5.6 php5.6-cli php5.6-mysql php5.6-ldap php5.6-curl php5.6-xsl php5.6-gd php-imagick php5.6-mcrypt php5.6-imagick
+sudo apt-get install -y git-core software-properties-common php5.6 php5.6-mbstring imagemagick libjpeg62 mariadb-server mariadb-client debconf-utils unzip xfonts-75dpi default-jre libgamin0 gamin openjdk-7-jdk openjdk-8-jdk xfonts-base ruby ant libbatik-java libreoffice-core libreoffice-common libreoffice-writer libapache2-mod-php5.6 php5.6-cli php5.6-mysql php5.6-ldap php5.6-curl php5.6-xsl php5.6-gd php-imagick php5.6-mcrypt php5.6-imagick ffmpeg
 
 # install node.js and npm
 curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -


### PR DESCRIPTION
One feature of the lightning viewer is to take the first frame of video documents and use that as the event preview. ImageMagick can do that, but it actually uses ffmpeg under the hood. This pull request imstalls ffmpeg, however because ffmpeg isn't officially supported in 14.04 (see https://askubuntu.com/questions/432542/is-ffmpeg-missing-from-the-official-repositories-in-14-04), a third party version has to be used instead. The third party version shouldn't be required when openeyes is updated to use 18.04